### PR TITLE
Release 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6863,7 +6863,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vl-convert"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-python"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "futures",
  "lazy_static",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-rs"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "deno_core",
  "deno_emit",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-vendor"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "dircpy",

--- a/vl-convert-python/Cargo.toml
+++ b/vl-convert-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl-convert-python"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl-convert-rs"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/vl-convert-vendor/Cargo.toml
+++ b/vl-convert-vendor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl-convert-vendor"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/vl-convert/Cargo.toml
+++ b/vl-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl-convert"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 readme = "README.md"


### PR DESCRIPTION
vl-convert@1.6.1
vl-convert-python@1.6.1
vl-convert-rs@1.6.1
vl-convert-vendor@1.6.1

Generated by cargo-workspaces